### PR TITLE
Add a test helper that exercises regexes

### DIFF
--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -22,7 +22,6 @@ module ChatOps::Controller::TestCaseHelpers
       metadata["regex"] = Regexp.new("^#{metadata["regex"]}$", "i")
       metadata
     }
-    matcher = matchers.first { |matcher| matcher["regex"].match(message) }
     matcher = matchers.find { |matcher| matcher["regex"].match(message) }
 
     raise NoMatchingCommandRegex.new("No command matches '#{message}'") unless matcher

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -214,6 +214,12 @@ describe ActionController::Base, type: :controller do
         expect(request.params["params"]["app"]).to eq "foobar"
         expect(chatop_response).to eq "You can deploy foobar just fine."
       end
+
+      it "anchors regexes" do
+        expect {
+          chat "too bad that this message doesn't start with where can i deploy foobar", "bhuga"
+        }.to raise_error(ChatOps::Controller::TestCaseHelpers::NoMatchingCommandRegex)
+      end
     end
   end
 end


### PR DESCRIPTION
This came up on CI: How do we test some of these regexes?

This gives us a new test helper, `chat`, that actually parses a chat message, matches it against parsed regexes, turns it into parameters, and lets us compare that everything's fine.

cc @jakedouglas, who mentioned this on the CI pull https://github.com/github/ci/pull/1013
