### PR TITLE
README: ::ChatOps::ControllerHelpers -> ::ChatOps::Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal controller example:
 
 ```ruby
 class ChatOpsController < ApplicationController
-  include ::ChatOps::ControllerHelpers
+  include ::ChatOps::Controller
 
   chatops_namespace :echo
 


### PR DESCRIPTION
Doesn't look like we have a `ControllerHelpers` and the real world usage appears to be `include ChatOps::Controller`.

cc @bhuga @jameswhite 
