### PR TITLE
support chatops error responses

### DIFF
--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -14,6 +14,7 @@ module ChatOps
       render :json => {
         namespace: self.class.chatops_namespace,
         help: self.class.chatops_help,
+        error_response: self.class.chatops_error_response,
         methods: chatops }
     end
 
@@ -104,18 +105,16 @@ module ChatOps
         define_method method_name, &block
       end
 
-      def chatops_namespace(namespace = nil)
-        if namespace.present?
-          @chatops_namespace = namespace
+      %w{namespace help error_response}.each do |setting|
+        method_name = "chatops_#{setting}".to_sym
+        variable_name = "@#{method_name}".to_sym
+        define_method method_name do |*args|
+          assignment = args.first
+          if assignment.present?
+            instance_variable_set variable_name, assignment
+          end
+          instance_variable_get variable_name.to_sym
         end
-        @chatops_namespace
-      end
-
-      def chatops_help(help = nil)
-        if help.present?
-          @chatops_help = help
-        end
-        @chatops_help
       end
 
       def chatops

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -5,6 +5,7 @@ describe ActionController::Base, type: :controller do
     include ChatOps::Controller
     chatops_namespace :test
     chatops_help "ChatOps of and relating to testing"
+    chatops_error_response "Try checking haystack?"
 
     before_filter :ensure_app_given, :only => [:wcid]
 
@@ -92,6 +93,7 @@ describe ActionController::Base, type: :controller do
       expect(json_response).to eq({
         "namespace" => "test",
         "help" => "ChatOps of and relating to testing",
+        "error_response" => "Try checking haystack?",
         "methods" => {
           "wcid" => {
             "help" => "where can i deploy?",


### PR DESCRIPTION
Allows setting a generic string, `chatops_error_response`, that will be displayed when things fail. This lets applications link to haystack or support forms or whatever when they throw a 500.
