### PR TITLE
allow naked boolean arguments in test helpers

### DIFF
--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -58,6 +58,7 @@ module ChatOps::Controller::TestCaseHelpers
       arg = command_string[last_index..-1]
       matches = arg.match(/ --(\S+)(.*)/)
       params[matches[1]] = matches[2].strip
+      params[matches[1]] = "true" unless params[matches[1]].present?
       command_string = command_string.slice(0, last_index)
     end
 

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -227,6 +227,13 @@ describe ActionController::Base, type: :controller do
         expect(chatop_response).to eq "You can deploy foobar just fine."
       end
 
+      it "works with boolean arguments" do
+        chat "where can i deploy foobar --this-is-sparta", "bhuga"
+        expect(request.params["action"]).to eq "wcid"
+        expect(request.params["user"]).to eq "bhuga"
+        expect(request.params["params"]["this-is-sparta"]).to eq "true"
+      end
+
       it "anchors regexes" do
         expect {
           chat "too bad that this message doesn't start with where can i deploy foobar", "bhuga"


### PR DESCRIPTION
Allows sending `--foo` and getting `{foo: "true"}` as a param. Hubot supports this in https://github.com/github/hubot-classic/pull/2224
