### PR TITLE
Add ruby fence name to test block

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ end
 
 It's easy to test:
 
-```
+```ruby
 class MyControllerTestCase < ActionController::TestCase
   include Chatops::Controller::TestCaseHelpers
   before do


### PR DESCRIPTION
Noticed it was missing in the test example.