### PR TITLE
protocol: fix potentially confusing example request

### DIFF
--- a/docs/protocol-description.md
+++ b/docs/protocol-description.md
@@ -113,7 +113,7 @@ Accept: application/json
 Content-type: application/json
 Content-length: 77
 
-{"user":"bhuga","method":"wcid","params":{"app": "hubot"},"room_id":"developer-experience"}
+{"user":"bhuga","method":"options","params":{"app": "hubot"},"room_id":"developer-experience"}
 ```
 
 The CRPC server should respond with output like the following:


### PR DESCRIPTION
This ensures that all the examples in the protocol docs are consistent. The method _name_ is `options`, while the _path_ is `wcid`. /cc #25