### PR TITLE
Add support for mention_slug parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ this regex. Arguments will be available in the `params` hash. `params[:user]`
 and `params[:room_id]` are special, and will be set by the client. `user` will
 always be the login of the user typing the command, and `room_id` will be where
 it was typed.
+The optional `mention_slug` parameter will provide the name to use to refer to
+the user when sending a message; this may or may not be the same thing as the
+username, depending on the chat system being used.
 
 You can return `jsonrpc_success` with a string to return text to chat. If you
 have an input validation or other handle-able error, you can use

--- a/docs/protocol-description.md
+++ b/docs/protocol-description.md
@@ -43,6 +43,7 @@ chat message matches a command's regex matcher, the CRPC client creates a method
 invocation. A method invocation is a JSON object with the following fields:
 
  * `user`: A slug username corresponding to to the command giver's GitHub login.
+ * `mention_slug`: Optional. If provided, a string which should be used to mention the user when sending a message in response. For example, Slack requires that users be mentioned using user IDs instead of usernames.
  * `room_id`: A slug room name where the command originated.
  * `method`: The method name, without namespace, of the matching regex.
  * `params`: A mapping of parameter names to matches extracted from named capture groups in the command's regex. Parameters that are empty or null should not be passed.

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -28,7 +28,7 @@ module Chatops
 
     def process(*args)
       scrubbed_params = jsonrpc_params.except(
-        :user, :method, :controller, :action, :params, :room_id)
+        :user, :mention_slug, :method, :controller, :action, :params, :room_id)
 
       scrubbed_params.each { |k, v| params[k] = v }
 


### PR DESCRIPTION
Currently, the protocol assumes that the GitHub login supplied will always be the appropriate username to use to refer to the user in chat messages. This isn't always a safe assumption.

The motivating factor for this change is Slack's recent change to usernames: https://api.slack.com/changelog/2017-09-the-one-about-usernames

However, it's also possible to imagine other systems in which a user's GitHub username is distinct from their chat username; providing this field should support a wider variety of possible usecases.