### PR TITLE
Ensure unspecified params are nil, not an empty string

### DIFF
--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -31,6 +31,11 @@ module Chatops
         :user, :mention_slug, :method, :controller, :action, :params, :room_id)
 
       scrubbed_params.each { |k, v| params[k] = v }
+      # As of Rails 5, values we expected to be nil may end up
+      # being empty strings instead
+      if params[:params].present?
+        params["params"].reject! { |k, v| v == "" }
+      end
 
       if params[:chatop].present?
         params[:action] = params[:chatop]

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -371,6 +371,11 @@ describe ActionController::Base, type: :controller do
         chat "test-prefix where can i deploy foobar --this-is-sparta", "bhuga"
         expect(request.params["chatop"]).to eq "wcid"
       end
+
+      it "ensures unprovided arguments are nil" do
+        chat "where can i deploy", "bhuga"
+        expect(controller.send(:params)["params"]["app"]).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes a regression we noticed in Rails 5. Unspecified matched regex values were being returned as empty strings, not nil; this broke chatops-controller apps which did truthiness and nil checks against their parameters. I tested this new test against both Rails 4 and 5; should be compatible with both.