### PR TITLE
Add support for "attachment" feature

### DIFF
--- a/docs/protocol-description.md
+++ b/docs/protocol-description.md
@@ -70,6 +70,7 @@ but it is important that `result` be sufficient on its own.
     * `image_url`: An image URL to display as the button, will generally take precedence
     * `command`: The command to use when the button is clicked
  * `image_url`: An image URL to be included with the response
+ * `attachment`: Optional boolean which hints the recipient to format the message as an attachment, if supported by its protocol. Because this is a hint, it may be ignored by clients. If not specified, it defaults to false.
 
 CRPC may also produce error JSON according to the JSON-RPC spec, consisting of
 an object containing an `error` object with a `message` string. This is

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -56,8 +56,11 @@ module Chatops
       params["params"] || {}
     end
 
-    def jsonrpc_success(message)
-      jsonrpc_response :result => message.to_s
+    def jsonrpc_success(message, options: {})
+      response = { :result => message.to_s }
+      # do not allow options to override message
+      options.delete(:result)
+      jsonrpc_response response.merge(options)
     end
     alias_method :chatop_send, :jsonrpc_success
 

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -56,6 +56,8 @@ module Chatops
       params["params"] || {}
     end
 
+    # `options` supports any of the optional fields documented
+    # in the [protocol](../../docs/protocol-description.md).
     def jsonrpc_success(message, options: {})
       response = { :result => message.to_s }
       # do not allow options to override message


### PR DESCRIPTION
This adds support for a new option, which allows servers to hint to clients that they should format the response as a separate attachment instead of returning it inline as a message. Because this is a hint, and because not all clients will support an attachment mode, clients are allowed to ignore this field for any reason.

For example, Slack supports "snippets", which are arbitrary text documents sent as attachments. These don't use Slack's normal message formatting and have a larger filesize limit.

cc @kpaulisse, who requested this feature.