### PR TITLE
Refactor params handling

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,11 +14,6 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-
-
-
-
-
 Bundler::GemHelper.install_tasks
 
 require 'rake/testtask'
@@ -29,6 +24,5 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
 end
-
 
 task default: :test

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -50,6 +50,11 @@ module Chatops
     protected
 
     def setup_params
+      json_body.each do |key, value|
+        next if params.has_key? key
+        params[key] = value
+      end
+
       permitted_params = %i[
         action
         chatop
@@ -74,6 +79,14 @@ module Chatops
       end
 
       self.params = params.permit(*permitted_params)
+    end
+
+    def json_body
+      hash = {}
+      if request.content_type =~ %r/\Aapplication\/json\Z/i
+        hash = GitHub::JSON.parse(request.raw_post) || {}
+      end
+      hash.with_indifferent_access
     end
 
     def jsonrpc_params

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -27,6 +27,8 @@ module Chatops
     end
 
     def process(*args)
+      setup_params
+
       if params[:chatop].present?
         params[:action] = params[:chatop]
         args[0] = params[:action]
@@ -46,6 +48,33 @@ module Chatops
     end
 
     protected
+
+    def setup_params
+      permitted_params = %i[
+        action
+        chatop
+        controller
+        mention_slug
+        method
+        room_id
+        user
+      ]
+
+      chatop_name =
+        if params[:chatop].present?
+          params[:chatop].to_sym
+        elsif params[:action].present?
+          params[:action].to_sym
+        else
+          nil
+        end
+
+      if chatop = self.class.chatops[chatop_name]
+        permitted_params << { params: chatop[:params] }
+      end
+
+      self.params = params.permit(*permitted_params)
+    end
 
     def jsonrpc_params
       params["params"] || {}

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -40,7 +40,7 @@ module Chatops
         end
       end
 
-      super *args
+      super(*args)
     rescue AbstractController::ActionNotFound
       return jsonrpc_method_not_found
     end

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -27,11 +27,6 @@ module Chatops
     end
 
     def process(*args)
-      scrubbed_params = jsonrpc_params.except(
-        :user, :mention_slug, :method, :controller, :action, :params, :room_id)
-
-      scrubbed_params.each { |k, v| params[k] = v }
-
       if params[:chatop].present?
         params[:action] = params[:chatop]
         args[0] = params[:action]

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -27,7 +27,7 @@ module Chatops
     end
 
     def process(*args)
-      setup_params
+      setup_params!
 
       if params[:chatop].present?
         params[:action] = params[:chatop]
@@ -49,7 +49,7 @@ module Chatops
 
     protected
 
-    def setup_params
+    def setup_params!
       json_body.each do |key, value|
         next if params.has_key? key
         params[key] = value
@@ -65,8 +65,7 @@ module Chatops
         user
       ]
 
-      chatop_name =
-        if params[:chatop].present?
+      chatop_name = if params[:chatop].present?
           params[:chatop].to_sym
         elsif params[:action].present?
           params[:action].to_sym

--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -57,7 +57,7 @@ module Chatops::Controller::TestCaseHelpers
     match_data = matcher["regex"].match(command)
     jsonrpc_params = named_params.dup
     matcher["params"].each do |param|
-      jsonrpc_params[param] = match_data[param.to_sym]
+      jsonrpc_params[param] ||= match_data[param.to_sym]
     end
     jsonrpc_params.merge!(user: user, room_id: room_id, mention_slug: user)
     chatop matcher["name"].to_sym, jsonrpc_params

--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -50,7 +50,7 @@ module Chatops::Controller::TestCaseHelpers
 
     named_params, command = extract_named_params(message)
 
-    matcher = matchers.find { |matcher| matcher["regex"].match(command) }
+    matcher = matchers.find { |m| m["regex"].match(command) }
 
     raise NoMatchingCommandRegex.new("No command matches '#{command}'") unless matcher
 

--- a/lib/chatops/controller/version.rb
+++ b/lib/chatops/controller/version.rb
@@ -1,3 +1,3 @@
 module ChatopsController
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -14,8 +14,8 @@ describe ActionController::Base, type: :controller do
     chatop :wcid,
     /(?:where can i deploy|wcid)(?: (?<app>\S+))?/,
     "where can i deploy?" do
-      return jsonrpc_invalid_params("I need nope, sorry") if params[:app] == "nope"
-      jsonrpc_success "You can deploy #{params["app"]} just fine."
+      return jsonrpc_invalid_params("I need nope, sorry") if jsonrpc_params[:app] == "nope"
+      jsonrpc_success "You can deploy #{jsonrpc_params["app"]} just fine."
     end
 
     chatop :foobar,
@@ -35,7 +35,7 @@ describe ActionController::Base, type: :controller do
     end
 
     def ensure_app_given
-      return jsonrpc_invalid_params("I need an app, every time") unless params[:app].present?
+      return jsonrpc_invalid_params("I need an app, every time") unless jsonrpc_params[:app].present?
     end
   end
 


### PR DESCRIPTION
The goal of this pull request is to refactor how params are handled by chatops and to improve security by enforcing the params that can be passed to JSON RPC endpoints. This is accomplished by inspecting the named values from the chatops regular expressions and only allowing those named values to be present in the `jsonrpc_params`. This has the nice side effect of forcing chatops commands to be well formed and well documented.

I've also fixed up a few warnings in the codebase.

Oh, and I fixed the test helper to mirror the generic argument handling as implemented by the hubot-chatops-rpc reference implementation.

/cc @eileencodes && @bkuhlmann