### PR TITLE
Accept params in short form like -v and not only --verbose

### DIFF
--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -79,9 +79,9 @@ module Chatops::Controller::TestCaseHelpers
   def extract_named_params(command_string)
     params = {}
 
-    while last_index = command_string.rindex(" --")
+    while last_index = command_string.rindex(/ --?/)
       arg = command_string[last_index..-1]
-      matches = arg.match(/ --(\S+)(.*)/)
+      matches = arg.match(/ --?(\S+)(.*)/)
       params[matches[1]] = matches[2].strip
       params[matches[1]] = "true" unless params[matches[1]].present?
       command_string = command_string.slice(0, last_index)

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -342,22 +342,24 @@ describe ActionController::Base, type: :controller do
       end
 
       it "works with generic arguments" do
-        chat "where can i deploy foobar --fruit apple --vegetable green celery", "bhuga"
+        chat "where can i deploy foobar --fruit apple --vegetable green celery -v", "bhuga"
         expect(request.params["action"]).to eq "execute_chatop"
         expect(request.params["chatop"]).to eq "wcid"
         expect(request.params["user"]).to eq "bhuga"
         expect(request.params["params"]["app"]).to eq "foobar"
         expect(request.params["params"]["fruit"]).to eq "apple"
         expect(request.params["params"]["vegetable"]).to eq "green celery"
+        expect(request.params["params"]["v"]).to eq "true"
         expect(chatop_response).to eq "You can deploy foobar just fine."
       end
 
       it "works with boolean arguments" do
-        chat "where can i deploy foobar --this-is-sparta", "bhuga"
+        chat "where can i deploy foobar --this-is-sparta -s", "bhuga"
         expect(request.params["action"]).to eq "execute_chatop"
         expect(request.params["chatop"]).to eq "wcid"
         expect(request.params["user"]).to eq "bhuga"
         expect(request.params["params"]["this-is-sparta"]).to eq "true"
+        expect(request.params["params"]["s"]).to eq "true"
       end
 
       it "anchors regexes" do


### PR DESCRIPTION
I'm currently moving so chatops commands from git-infrastructure to use chatops RPC (see https://github.com/github/github/pull/98780).

Some of the commands there have short forms like `-v` for `--verbose`. We probably want a more complex solution long term to somehow link those so `-v` and `--verbose` result in `--verbose` being true, but I'm wondering if this is good enough for now?