### PR TITLE
Proposal to add an optional message id to the CRPC protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ always be the login of the user typing the command, and `room_id` will be where
 it was typed.
 The optional `mention_slug` parameter will provide the name to use to refer to
 the user when sending a message; this may or may not be the same thing as the
-username, depending on the chat system being used.
+username, depending on the chat system being used. The optional `message_id` parameter will provide a reference to the message that invoked the rpc.
 
 You can return `jsonrpc_success` with a string to return text to chat. If you
 have an input validation or other handle-able error, you can use

--- a/docs/protocol-description.md
+++ b/docs/protocol-description.md
@@ -44,6 +44,7 @@ invocation. A method invocation is a JSON object with the following fields:
 
  * `user`: A slug username corresponding to to the command giver's GitHub login.
  * `mention_slug`: Optional. If provided, a string which should be used to mention the user when sending a message in response. For example, Slack requires that users be mentioned using user IDs instead of usernames.
+ * `message_id`: Optional. If provided, an id that uniquely identifies the message that generated the CRPC call. Useful for linking back to the original command to provide context.
  * `room_id`: A slug room name where the command originated.
  * `method`: The method name, without namespace, of the matching regex.
  * `params`: A mapping of parameter names to matches extracted from named capture groups in the command's regex. Parameters that are empty or null should not be passed.

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -57,7 +57,7 @@ module Chatops
 
       @jsonrpc_params = params.delete(:params) if params.has_key? :params
 
-      self.params = params.permit(:action, :chatop, :controller, :id, :mention_slug, :method, :room_id, :user)
+      self.params = params.permit(:action, :chatop, :controller, :id, :mention_slug, :message_id, :method, :room_id, :user)
     end
 
     def jsonrpc_params

--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -21,12 +21,14 @@ module Chatops::Controller::TestCaseHelpers
     user = args.delete :user
     room_id = args.delete :room_id
     mention_slug = args.delete :mention_slug
+    message_id = args.delete :message_id
 
     params = {
       :params => args,
       :room_id => room_id,
       :user => user,
       :mention_slug => mention_slug,
+      :message_id => message_id,
     }
 
     major_version = Rails.version.split('.')[0].to_i
@@ -37,7 +39,7 @@ module Chatops::Controller::TestCaseHelpers
     end
   end
 
-  def chat(message, user, room_id = "123")
+  def chat(message, user, room_id = "123", message_id = "456")
     get :list
     json_response = JSON.load(response.body)
     matchers = json_response["methods"].map { |name, metadata|
@@ -59,7 +61,7 @@ module Chatops::Controller::TestCaseHelpers
     matcher["params"].each do |param|
       jsonrpc_params[param] ||= match_data[param.to_sym]
     end
-    jsonrpc_params.merge!(user: user, room_id: room_id, mention_slug: user)
+    jsonrpc_params.merge!(user: user, room_id: room_id, mention_slug: user, message_id: message_id)
     chatop matcher["name"].to_sym, jsonrpc_params
   end
 

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -393,6 +393,15 @@ describe ActionController::Base, type: :controller do
         expect(request.params["params"]["this-is-sparta"]).to eq "true"
       end
 
+      it "sends along all the parameters" do
+        chat "where can i deploy foobar", "my_username", "room_id_5", "message_id_6"
+        expect(request.params["action"]).to eq "execute_chatop"
+        expect(request.params["chatop"]).to eq "wcid"
+        expect(request.params["user"]).to eq "my_username"
+        expect(request.params["room_id"]).to eq "room_id_5"
+        expect(request.params["message_id"]).to eq "message_id_6"
+      end
+
       it "anchors regexes" do
         expect {
           chat "too bad that this message doesn't start with where can i deploy foobar", "bhuga"

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -25,6 +25,13 @@ describe ActionController::Base, type: :controller do
       jsonrpc_success "You just foo and bar like it just don't matter"
     end
 
+    chatop :proxy_parameters,
+    /(?:proxy_parameters)/,
+    "proxy parameters back to test" do
+      response = { :params => params, :jsonrpc_params => jsonrpc_params }.to_json
+      jsonrpc_success response
+    end
+
     skip_before_action :ensure_method_exists, only: :non_chatop_method
     def non_chatop_method
       render :plain => "Why would you have something thats not a chatop?"
@@ -228,6 +235,12 @@ describe ActionController::Base, type: :controller do
             "regex" => /(?:how can i foo and bar all at once)?/.source,
             "params" => [],
             "path" => "foobar"
+          },
+          "proxy_parameters" => {
+            "help" => "proxy parameters back to test",
+            "regex" => /(?:proxy_parameters)/.source,
+            "params" => [],
+            "path" => "proxy_parameters"
           }
         },
         "version" => "3"
@@ -292,6 +305,26 @@ describe ActionController::Base, type: :controller do
       })
       expect(response.status).to eq 200
     end
+
+    it "passes all expected paramters" do
+      rails_flexible_post :execute_chatop, {
+        :chatop => "proxy_parameters",
+        :user => "foo",
+        :mention_slug => "mention_slug_here",
+        :message_id => "message_id_here",
+        :room_id => "#someroom",
+        :unknown_key => "few" # This should get ignored
+      }, {
+       "app" => "foo" 
+      }
+      expect(json_response).to eq({
+        "jsonrpc" => "2.0",
+        "id" => nil,
+        "result" => "{\"params\":{\"action\":\"proxy_parameters\",\"chatop\":\"proxy_parameters\",\"controller\":\"anonymous\",\"mention_slug\":\"mention_slug_here\",\"message_id\":\"message_id_here\",\"room_id\":\"#someroom\",\"user\":\"foo\"},\"jsonrpc_params\":{\"app\":\"foo\"}}"
+      })
+      expect(response.status).to eq 200
+    end 
+
 
     it "uses typical controller fun like before_action" do
       rails_flexible_post :execute_chatop, :chatop => "wcid", :user => "foo"


### PR DESCRIPTION
👋 I propose we add an optional message id to the CRPC protocol to allow the chatops controller to generate links back to the original chat op message. This is useful when interfacing with 3rd party services so anyone can quickly jump back to the slack conversation that resulted in a chat op being issued, providing context for why the decision to call that chat op was made.

### Example

Imagine the following slack conversation
```
Person 1: We're seeing elevated 500s after the last deploy, suggesting a rollback
Person 2: I think it could just be the workers restarting
Person 1: The error rate is continuing to rise rather than fall, I think we should rollback
Person 2: Ok, you're right, let's rollback
Person 1: .deployservice rollback
```

Later when viewing a hypothetical "deployservice" UI it would be useful to jump back to the point in the slack history where this conversation took place to figure out why the rollback was issued. By providing the message id, we can generate a slack permalink: `https://mycompany.slack.com/archives/#{room}/p#{message_id}`

/cc @mistydemeo @technicalpickles 
