### PR TITLE
Support multiline chatop pattern matching

### DIFF
--- a/lib/chatops/controller/test_case_helpers.rb
+++ b/lib/chatops/controller/test_case_helpers.rb
@@ -46,7 +46,7 @@ module Chatops::Controller::TestCaseHelpers
       metadata = metadata.dup
       metadata["name"] = name
       prefix = chatops_prefix ? "#{chatops_prefix} " : ""
-      metadata["regex"] = Regexp.new("^#{prefix}#{metadata["regex"]}$", "i")
+      metadata["regex"] = %r{\A#{prefix}#{metadata["regex"]}\z}im
       metadata
     }
 

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -439,6 +439,15 @@ describe ActionController::Base, type: :controller do
         expect(chatop_response).to eq "```\nbar\nbaz\nfoo\n```"
       end
 
+      it "matches patterns case-insensitively" do
+        chat "WCID foo", "laserlemon"
+        expect(request.params["action"]).to eq "execute_chatop"
+        expect(request.params["chatop"]).to eq "wcid"
+        expect(request.params["user"]).to eq "laserlemon"
+        expect(request.params["params"]["app"]).to eq "foo"
+        expect(chatop_response).to eq "You can deploy foo just fine."
+      end
+
       it "allows setting a v2 prefix" do
         chatops_prefix "test-prefix"
         chat "test-prefix where can i deploy foobar --this-is-sparta", "bhuga"


### PR DESCRIPTION
The test added is actually a decent example of how multiline chatop matching could be useful. My intended use is a command to complement a suite of existing commands that manage a list of terms. The new command would allow the entire dictionary of terms to be replaced in one fell swoop. For example:

> prefix fruits replace
> ```
> apple
> banana
> lemon
> ```