### PR TITLE
Reduce dependencies for chatops controller

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,12 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.5.7
+    - name: Set up Ruby 2.7.2
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5.7
+        ruby-version: 2.7.2
     - name: Build and test
       run: |
-        gem install bundler:1.16.1
         bundle install --binstubs
         bin/rspec

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby 2.5.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5.7
     - name: Build and test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 4.0'
+gem 'rails'
 
 group :development, :test do
   gem "rspec-rails", "~> 3"

--- a/chatops-controller.gemspec
+++ b/chatops-controller.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", ">= 4.0"
+  s.add_dependency "actionpack", ">= 4.0"
+  s.add_dependency "activesupport", ">= 4.0"
 
   s.add_development_dependency "rspec-rails", "~> 3"
   s.add_development_dependency "pry", "~> 0"

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  if Rails.version.starts_with?("5")
+  if Rails.version.start_with?("5")
     config.public_file_server.enabled = true
     config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
   else

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-if Rails.version.starts_with?("4")
+if Rails.version.start_with?("4")
   Rails.application.config.assets.version = '1.0'
 end
 

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -60,7 +60,7 @@ describe ActionController::Base, type: :controller do
   end
 
   def rails_flexible_post(path, outer_params, jsonrpc_params = nil)
-    if Rails.version.starts_with?("4")
+    if Rails.version.start_with?("4")
       post path, outer_params.merge("params" => jsonrpc_params)
     else
       jsonrpc_params ||= {}


### PR DESCRIPTION
When looking at options to reduce dependencies for a Rails app, my approach failed because we can't drop some Rails components because we use gems that express all of Rails as a dependency instead of the parts they need.

The chatops controller is one of those. It looks like though it only needs ActiveSupport & ActionPack so I reduced the dependencies here to just those parts.