### PR TITLE
Define Chatops::THREAD_STYLES

### DIFF
--- a/lib/chatops.rb
+++ b/lib/chatops.rb
@@ -1,4 +1,16 @@
 module Chatops
+  # THREAD_STYLES defines the various thread styles available to Hubot Chatops RPC.
+  # https://github.com/github/hubot-classic/blob/master/docs/rpc_chatops_protocol.md#executing-commands
+  THREAD_STYLES = {
+    # Channel thread style is a standard in-channel reply.
+    channel: 0,
+    # Threaded thread style will send the reply to a thread from the original message.
+    threaded: 1,
+    # Threaded and channel thread style will send the reply to a thread from the original message,
+    # and post an update into the channel as well (helpful when the original message in the thread is old).
+    threaded_and_channel: 2,
+  }.freeze
+
   def self.public_key
     ENV[public_key_env_var_name]
   end


### PR DESCRIPTION
ChatopsRPC has been updated to support thread styles, which allows a Chatops RPC call to reply either in the channel, in a thread of the original message, or both. The idea of this PR is to make defining a thread style something that is glanceable, therefore making the magic numerical values non-magical.

This PR is modeled after the `go-crpc` library: https://github.com/github/go-crpc/pull/39

Requires https://github.com/github/hubot-slack/pull/21, https://github.com/github/hubot-classic/pull/3920, and a documentation update to the link in the comment.

/cc @esirko 