### PR TITLE
Bump gem version to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ which will be accepted. This is helpful when rolling keys.
 
 ## Rails compatibility
 
-This gem is intended to work with rails 4.x and 5.x. If you find a version
+This gem is intended to work with rails 6.x and 7.x. If you find a version
 with a problem, please report it in an issue.
 
 ## Development

--- a/lib/chatops/controller/version.rb
+++ b/lib/chatops/controller/version.rb
@@ -1,3 +1,3 @@
 module ChatopsController
-  VERSION = "4.1.0"
+  VERSION = "5.0.0"
 end


### PR DESCRIPTION
In https://github.com/github/chatops-controller/pull/54 we changed the rails req from `>= 4` to `>= 6`.   This PR updates the README and bumps the gem version.