### PR TITLE
Permit raw_command

### DIFF
--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -57,7 +57,7 @@ module Chatops
 
       @jsonrpc_params = params.delete(:params) if params.has_key? :params
 
-      self.params = params.permit(:action, :chatop, :controller, :id, :mention_slug, :message_id, :method, :room_id, :user)
+      self.params = params.permit(:action, :chatop, :controller, :id, :mention_slug, :message_id, :method, :room_id, :user, :raw_command)
     end
 
     def jsonrpc_params


### PR DESCRIPTION
This is to allow implementation of another feature that sends the raw_command, in addition to the parsed command, to the chatops server so the server can parse the command itself.