### PR TITLE
fix: allow 5 mins time drift

### DIFF
--- a/lib/chatops.rb
+++ b/lib/chatops.rb
@@ -11,6 +11,8 @@ module Chatops
     threaded_and_channel: 2,
   }.freeze
 
+  ALLOWED_TIME_SKEW_MINS = 5
+
   def self.public_key
     ENV[public_key_env_var_name]
   end

--- a/lib/chatops/controller.rb
+++ b/lib/chatops/controller.rb
@@ -168,8 +168,8 @@ module Chatops
     def ensure_valid_chatops_timestamp
       @chatops_timestamp = request.headers["Chatops-Timestamp"]
       time = Time.iso8601(@chatops_timestamp)
-      if !(time > 1.minute.ago && time < 1.minute.from_now)
-        return jsonrpc_error(-32803, 403, "Chatops timestamp not within 1 minute of server time: #{@chatops_timestamp} vs #{Time.now.utc.iso8601}")
+      if !(time > Chatops::ALLOWED_TIME_SKEW_MINS.minute.ago && time < Chatops::ALLOWED_TIME_SKEW_MINS.minute.from_now)
+        return jsonrpc_error(-32803, 403, "Chatops timestamp not within #{Chatops::ALLOWED_TIME_SKEW_MINS} minutes of server time: #{@chatops_timestamp} vs #{Time.now.utc.iso8601}")
       end
     rescue ArgumentError, TypeError
       # time parsing or missing can raise these

--- a/lib/chatops/controller/version.rb
+++ b/lib/chatops/controller/version.rb
@@ -1,3 +1,3 @@
 module ChatopsController
-  VERSION = "5.2.0"
+  VERSION = "5.3.0"
 end

--- a/spec/lib/chatops/controller_spec.rb
+++ b/spec/lib/chatops/controller_spec.rb
@@ -177,9 +177,9 @@ describe ActionController::Base, type: :controller do
     expect(response.status).to eq 403
   end
 
-  it "doesn't allow requests more than 1 minute old" do
+  it "doesn't allow requests more than 5 minute old" do
     nonce = SecureRandom.hex(20)
-    timestamp = 2.minutes.ago.utc.iso8601
+    timestamp = 6.minutes.ago.utc.iso8601
     request.headers["Chatops-Nonce"] = nonce
     request.headers["Chatops-Timestamp"] = timestamp
     digest = OpenSSL::Digest::SHA256.new
@@ -188,12 +188,12 @@ describe ActionController::Base, type: :controller do
     request.headers["Chatops-Signature"] = "Signature keyid=foo,signature=#{signature}"
     get :list
     expect(response.status).to eq 403
-    expect(response.body).to include "Chatops timestamp not within 1 minute"
+    expect(response.body).to include "Chatops timestamp not within 5 minutes"
   end
 
-  it "doesn't allow requests more than 1 minute in the future" do
+  it "doesn't allow requests more than 5 minute in the future" do
     nonce = SecureRandom.hex(20)
-    timestamp = 2.minutes.from_now.utc.iso8601
+    timestamp = 6.minutes.from_now.utc.iso8601
     request.headers["Chatops-Nonce"] = nonce
     request.headers["Chatops-Timestamp"] = timestamp
     digest = OpenSSL::Digest::SHA256.new
@@ -202,7 +202,7 @@ describe ActionController::Base, type: :controller do
     request.headers["Chatops-Signature"] = "Signature keyid=foo,signature=#{signature}"
     get :list
     expect(response.status).to eq 403
-    expect(response.body).to include "Chatops timestamp not within 1 minute"
+    expect(response.body).to include "Chatops timestamp not within 5 minutes"
   end
 
   it "does not add authentication to non-chatops routes" do


### PR DESCRIPTION
Currently allowed 1 minute max timestamp skew is too strict and can be problematic during networking issues.

This PR bumps the limit to 5 minutes.