### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/github/chatops-controller/security/code-scanning/1](https://github.com/github/chatops-controller/security/code-scanning/1)

The best way to fix this problem is to add a `permissions:` block to the workflow, specifying the minimum required privilege. Since the workflow only needs to check out code and install/test dependencies (no write operations to the repository, issues, or pull requests), the minimal permission `contents: read` is adequate. This should be added at the root level of the workflow YAML file, immediately after the `name:` and before the `on:` key, to apply to all jobs in the workflow unless overridden at the job level. No imports or special definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
